### PR TITLE
Version 0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,7 @@ data/detect/
 data/ocr-test/
 
 img/
-data/student-data/
-data/test-download/
-data/caption-tests/
+data/
 vector/
 *.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aidapta"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     {name = "Manuel Garcia", email = "m.g.garciaalvarez@tudelft.nl"},
 ]

--- a/src/aidapta/metadata.py
+++ b/src/aidapta/metadata.py
@@ -205,8 +205,12 @@ class Metadata:
     purl: List = field(init=False) # persistent URL
     type_resource: str = field(init=False) # type of resource
     web_url: str = field(init=False, default=None) # URL at Educational Repository
-    
+    # total number of images/visuals extracted from the PDF files for
+    # this entry in the repository
+    total_visuals: Optional[int] = field(init=False, default=0)
     visuals: Optional[List[Visual]] = field(init=False, default=None)
+
+
     # pdf_location: Optional[str] = field(init=False, default=None) # location of the PDF file
 
     def set_metadata(self, metadata: dict) -> None:
@@ -345,6 +349,9 @@ class Metadata:
         if not self.visuals:
             self.visuals = []
         self.visuals.append(visual)
+
+        # update total number of visuals
+        self.total_visuals += 1
 
     def as_dict(self) -> dict:
         """ Returns metadata as a dictionary """

--- a/src/aidapta/metadata.py
+++ b/src/aidapta/metadata.py
@@ -87,10 +87,13 @@ class Visual:
     document_page: int # page number in the document index
     bbox: List[int] # bounding box of the visual in the document page
     bbox_units: str # units of the bounding box
-    id : Optional[str] = field(init=True, default=str(uuid.uuid4())) # unique identifier
+    id : Optional[str] = field(init=False) # unique identifier
     caption: Optional[list] = field(init=False, default=None) # caption of the visual    
     visual_type: Optional[str] = field(init=False, default=None) # one of: photo, drawing, map, etc
     location: FilePath = field(init=False, default=None) # location where the visual is stored
+
+    def __post_init__(self):
+        self.id = str(uuid.uuid4())
 
     def set_visual_type(self, visual_type: str) -> None:
         """Sets the visual type. One of photo, drawing, map, etc.
@@ -320,10 +323,11 @@ class Metadata:
         if self.web_url and overwrite == False:
             raise ValueError('base URL already set. User overwrite=True to overwrite it.')
         else:
-            if self.uuid[:5] == 'uuid:': # some uuids start with uuid:
-                self.web_url = f'{base_url}{self.uuid}' 
-            else: # pure uuids do not start with uuid:
-                self.web_url = f'{base_url}uuid:{self.uuid}'
+            if self.uuid is not None:
+                if self.uuid[:5] == 'uuid:': # some uuids start with uuid:
+                    self.web_url = f'{base_url}{self.uuid}' 
+                else: # pure uuids do not start with uuid:
+                    self.web_url = f'{base_url}uuid:{self.uuid}'
     
     def add_visual(self, visual: Visual) -> None:
         """ Adds a visual to the metadata 

--- a/src/aidapta/metadata.py
+++ b/src/aidapta/metadata.py
@@ -38,6 +38,16 @@ class FilePath:
         None
         """
         self.root_path = root_path
+
+    def full_path(self) -> str:
+        """Returns the full path of the file path
+        
+        Returns
+        -------
+        str
+            full path of the file path
+        """
+        return str(os.path.join(self.root_path, self.file_path))
     
     def __str__(self) -> str:
         return os.path.join(self.root_path, self.file_path)
@@ -73,9 +83,11 @@ class Document:
     """
     Represents a document
     """
-    location: FilePath = field(init=False, default=None) # location where the visual is stored
-
-
+    location: FilePath = field(init=True, default=None) # location where the visual is stored
+    
+    def update_root_path(self, path: str) -> None:
+        """Updates the root path of the file path """
+        self.location.update_root_path(path)
 
 
 @dataclass
@@ -398,7 +410,7 @@ class Metadata:
 def main() -> None:
     from aidapta.utils import extract_mods_metadata
 
-    meta_blob = extract_mods_metadata('data-pipelines/data/00001.mods.xml')
+    meta_blob = extract_mods_metadata('/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/00002_mods.xml')
     
     person1 = Person(name='John Doe', role='author')
     person2 = Person(name='Jane Doe', role='mentor')
@@ -408,11 +420,12 @@ def main() -> None:
     faculty1 = Faculty(name='Faculty of Architecture', departments=[department1])
 
     document1 = Document(location='data-pipelines/data/4563050_AmberLuesink_P5Report_TheRevivaloftheJustCity.pdf')
+    print(document1.location )
 
-    meta_data = Metadata(documents=[document1])
-    meta_data.set_metadata(meta_blob)
+    # meta_data = Metadata(documents=[document1])
+    # meta_data.set_metadata(meta_blob)
 
-    print(meta_data.as_dict())
+    # print(meta_data.as_dict())
     # meta_data.write_to_csv('data-pipelines/data/metadata.csv')
 
     # print(meta_data.as_dataframe())

--- a/src/aidapta/metadata.py
+++ b/src/aidapta/metadata.py
@@ -12,6 +12,37 @@ from typing import Optional, List
 
 
 @dataclass
+class FilePath:
+    """
+    Represents a file path
+    """
+    root_path: str
+    file_path: str
+
+    def __post_init__(self):
+        if not isinstance(self.root_path, str):
+            raise TypeError("root_path must be a string")
+        if not isinstance(self.file_path, str):
+            raise TypeError("file_path must be a string")
+
+    def update_root_path(self, root_path: str) -> None:
+        """Updates the root path of the file path
+        
+        Parameters
+        ----------
+        root_path: str
+            new root path
+        
+        Returns
+        -------
+        None
+        """
+        self.root_path = root_path
+    
+    def __str__(self) -> str:
+        return os.path.join(self.root_path, self.file_path)
+
+@dataclass
 class Person:
     """
     Represents a person 
@@ -42,39 +73,9 @@ class Document:
     """
     Represents a document
     """
-    location: str # location where the document is stored
+    location: FilePath = field(init=False, default=None) # location where the visual is stored
 
 
-@dataclass
-class FilePath:
-    """
-    Represents a file path
-    """
-    root_path: str
-    file_path: str
-
-    def __post_init__(self):
-        if not isinstance(self.root_path, str):
-            raise TypeError("root_path must be a string")
-        if not isinstance(self.file_path, str):
-            raise TypeError("file_path must be a string")
-
-    def update_root_path(self, root_path: str) -> None:
-        """Updates the root path of the file path
-        
-        Parameters
-        ----------
-        root_path: str
-            new root path
-        
-        Returns
-        -------
-        None
-        """
-        self.root_path = root_path
-    
-    def __str__(self) -> str:
-        return os.path.join(self.root_path, self.file_path)
 
 
 @dataclass

--- a/src/aidapta/ocr.py
+++ b/src/aidapta/ocr.py
@@ -15,7 +15,6 @@ from PIL.Image import Image
 from tqdm import tqdm
 from collections import Counter
 from pytesseract import image_to_string
-from PIL import Image
 
 
 def region_to_string(image: Image, bbox: list[float], config: str ='--oem 1 --psm 1') -> str:

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -23,6 +23,7 @@ from aidapta.layout import sort_layout_elements, create_output_dir
 from aidapta.metadata import Document, Metadata, Visual, FilePath
 from aidapta.captions import OffsetDistance
 from typing_extensions import Annotated 
+from pdfminer.pdftypes import PDFNotImplementedError
 
 # Disable PIL image size limit
 import PIL.Image
@@ -115,7 +116,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
             "width": 50,
             "height": 50,
         },
-        "resolution": 250, # analysis resolution, dpi
+        "resolution": 200, # analysis resolution, dpi
     }
 
     # Create output directory for the entry
@@ -267,12 +268,10 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
                     logger.warning("Image with unsupported format wasn't saved:" + img.name)
                 except UnboundLocalError:
                     logger.warning("Decocder doesn't support image stream, therefore not saved:" + img.name)
-                    
+                except PDFNotImplementedError:
+                    logger.warning("PDF stream unsupported format,  image not saved:" + img.name)
+
                 visual.set_location(FilePath( root_path=OUTPUT_DIR, file_path= entry_id + '/'  + pdf_file_name + '/' + image_file_name))
-                                    #      str(image_directory), # sets root path
-                                    #      image_file_name
-                                    #     ) 
-                                    # ) 
             
                 # add visual to entry
                 entry.add_visual(visual)
@@ -444,8 +443,8 @@ if __name__ == "__main__":
     
     # app()
 
-    pipeline("00000",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+    pipeline("00063",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/pdf-issues/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
             )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -116,7 +116,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
             "width": 50,
             "height": 50,
         },
-        "resolution": 200, # analysis resolution, dpi
+        "resolution": 250, # analysis resolution, dpi
     }
 
     # Create output directory for the entry
@@ -138,11 +138,6 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
 
     # Add the file handler to the logger
     logger.addHandler(file_handler)
-
-    # logging.basicConfig(filename=os.path.join(OUTPUT_DIR, 
-    #                     entry_id, entry_id + '.log'), 
-    #                     encoding='utf-8', 
-    #                     level=logging.INFO)
     
     logger.info("Starting Layout+OCR pipeline for entry: " + entry_id)
 
@@ -444,10 +439,10 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
   
 if __name__ == "__main__":
     
-    # app()
+    app()
 
-    pipeline("00001",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
-            )
+    # pipeline("00001",
+    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
+    #         )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -156,6 +156,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
         if f.startswith(entry_id) and f.endswith(".pdf"):
             PDF_FILES.append(DATA_DIR+f)
     
+    logger.info("PDF files in entry: " + str(len(PDF_FILES)))
 
     # INITIALISE METADATA OBJECT
     entry = Metadata()
@@ -408,10 +409,11 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
         shutil.copy2(MODS_FILE, temp_entry_directory)
 
 
-    for pdf in PDF_FILES:
-        if not os.path.exists(os.path.join(temp_entry_directory, os.path.basename(pdf) )):
-            shutil.copy2(pdf, temp_entry_directory)
-    
+    if len(PDF_FILES) > 0:
+        for pdf in PDF_FILES:
+            if not os.path.exists(os.path.join(temp_entry_directory, os.path.basename(pdf) )):
+                shutil.copy2(pdf, temp_entry_directory)
+        
     # SAVE METADATA TO files
 
     csv_file = str(os.path.join(entry_directory, entry_id) + "-metadata.csv")
@@ -434,8 +436,8 @@ if __name__ == "__main__":
     
     # app()
 
-    pipeline("00000",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+    pipeline("00039",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/pdf-issues/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
             )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -264,7 +264,8 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
                     # issue with MCYK images with 4 bits per pixel
                     # https://github.com/pdfminer/pdfminer.six/pull/854
                     logger.warning("Image with unsupported format wasn't saved:" + img.name)
-                    pass
+                except UnboundLocalError:
+                    logger.warning("Decocder doesn't support image stream, therefore not saved:" + img.name)
                     
                 visual.set_location(FilePath( root_path=OUTPUT_DIR, file_path= entry_id + '/'  + pdf_file_name + '/' + image_file_name))
                                     #      str(image_directory), # sets root path
@@ -275,6 +276,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
                 # add visual to entry
                 entry.add_visual(visual)
 
+        del pages # free memory
 
         # PROCESS PAGE USING OCR ANALYSIS
         logger.info("OCR input image resolution (DPI): " + str(ocr_settings["resolution"]))
@@ -439,7 +441,7 @@ if __name__ == "__main__":
     
     # app()
 
-    pipeline("00039",
+    pipeline("00097",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/pdf-issues/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -180,9 +180,12 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
     start_processing_time = time.time()
     for pdf in PDF_FILES:
         # print("--> Processing file:", pdf)
-        logger.info("Processing file: " + os.path.basename(pdf).split("/")[-1])
+        pdf_root = DATA_DIR
+        pdf_file_path = os.path.basename(pdf).split("/")[-1] # file name with extension
+        logger.info("Processing file: " + pdf_file_path)
         # create document object
-        pdf_document = Document(pdf)
+        pdf_formatted_path = FilePath(root_path=pdf_root, file_path=pdf_file_path)
+        pdf_document = Document(pdf_formatted_path)
         entry.add_document(pdf_document)
 
         # PREPARE OUTPUT DIRECTORY
@@ -193,7 +196,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
         # ocr_directory = create_output_dir(image_directory, "ocr")
 
         # PROCESS SINGLE PDF 
-        pdf_pages = extract_pages(pdf_document.location)
+        pdf_pages = extract_pages(pdf_document.location.full_path())
 
         pages = []
         for page in tqdm(pdf_pages, desc="Reading pages", unit="pages"):
@@ -285,7 +288,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
 
             # if page["images"] == []: # apply to pages where no images were found by layout analysis
             page_image = ocr.convert_pdf_to_image( # returns a list with one element
-                pdf_document.location, 
+                pdf_document.location.full_path(), 
                 dpi= ocr_settings["resolution"], 
                 first_page=page["page_number"], 
                 last_page=page["page_number"],
@@ -443,8 +446,8 @@ if __name__ == "__main__":
     
     # app()
 
-    pipeline("00063",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/pdf-issues/",
+    pipeline("00001",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
             )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -175,6 +175,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
                                          ocr_settings["caption"]["offset"][1])
 
     # PROCESS PDF FILES
+    pdf_document_counter = 1
     start_processing_time = time.time()
     for pdf in PDF_FILES:
         # print("--> Processing file:", pdf)
@@ -184,7 +185,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
         entry.add_document(pdf_document)
 
         # PREPARE OUTPUT DIRECTORY
-        pdf_file_name = pathlib.Path(pdf_document.location).stem
+        pdf_file_name = 'pdf-' + str(pdf_document_counter).zfill(3)
         image_directory = create_output_dir(entry_directory, 
                                             pdf_file_name) # returns a pathlib object
                
@@ -276,6 +277,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
                 # add visual to entry
                 entry.add_visual(visual)
 
+        pdf_document_counter += 1
         del pages # free memory
 
         # PROCESS PAGE USING OCR ANALYSIS
@@ -441,8 +443,8 @@ if __name__ == "__main__":
     
     # app()
 
-    pipeline("00097",
-            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/pdf-issues/",
+    pipeline("00000",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
             "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
             )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -416,8 +416,9 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
             if not os.path.exists(os.path.join(temp_entry_directory, os.path.basename(pdf) )):
                 shutil.copy2(pdf, temp_entry_directory)
         
-    # SAVE METADATA TO files
+    logger.info("Extracted visuals:" + str(entry.total_visuals))
 
+    # SAVE METADATA TO files
     csv_file = str(os.path.join(entry_directory, entry_id) + "-metadata.csv")
     json_file = str(os.path.join(entry_directory, entry_id) + "-metadata.json")
     entry.save_to_csv(csv_file)
@@ -439,10 +440,10 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
   
 if __name__ == "__main__":
     
-    app()
+    # app()
 
-    # pipeline("00001",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
-    #         )
+    pipeline("00001",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
+            )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -156,7 +156,6 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
         if f.startswith(entry_id) and f.endswith(".pdf"):
             PDF_FILES.append(DATA_DIR+f)
     
-    print(PDF_FILES)
 
     # INITIALISE METADATA OBJECT
     entry = Metadata()
@@ -177,7 +176,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
     # PROCESS PDF FILES
     start_processing_time = time.time()
     for pdf in PDF_FILES:
-        print("--> Processing file:", pdf)
+        # print("--> Processing file:", pdf)
         logger.info("Processing file: " + pdf)
         # create document object
         pdf_document = Document(pdf)
@@ -402,7 +401,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
 
     # Copy MODS file and PDF files to output directory
     temp_entry_directory = create_output_dir( os.path.join(TMP_DIR, entry_id))
-    print("temp_entry_directory", temp_entry_directory)
+    
 
     mods_file_name = pathlib.Path(MODS_FILE).stem + ".xml"
     if not os.path.exists(os.path.join(temp_entry_directory, mods_file_name)):
@@ -433,10 +432,10 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
   
 if __name__ == "__main__":
     
-    app()
+    # app()
 
-    # pipeline("00000",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
-    #         "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
-    #         )
+    pipeline("00000",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/",
+            "/home/manuel/Documents/devel/desing-handbook/data-pipelines/data/test/tmp/"
+            )

--- a/src/aidapta/pipelines/layout_ocr.py
+++ b/src/aidapta/pipelines/layout_ocr.py
@@ -178,7 +178,7 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
     start_processing_time = time.time()
     for pdf in PDF_FILES:
         # print("--> Processing file:", pdf)
-        logger.info("Processing file: " + pdf)
+        logger.info("Processing file: " + os.path.basename(pdf).split("/")[-1])
         # create document object
         pdf_document = Document(pdf)
         entry.add_document(pdf_document)
@@ -420,6 +420,9 @@ def pipeline(entry_id:str, data_directory: str, output_directory: str, temp_dire
     json_file = str(os.path.join(entry_directory, entry_id) + "-metadata.json")
     entry.save_to_csv(csv_file)
     entry.save_to_json(json_file)
+
+    if not entry.iid:
+        logger.warning("No identifier found in MODS file")
 
     # SAVE settings to json file
     settings_file = str(os.path.join(entry_directory, entry_id) + "-settings.json")

--- a/src/aidapta/utils.py
+++ b/src/aidapta/utils.py
@@ -165,8 +165,7 @@ def extract_mods_metadata(mods_file: str) -> dict:
             l = {"code": language.code, "authority": language.authority}
             languages.append(l)
         meta["language"] = languages
-
-        print(record.identifiers)
+        
         # Identifiers
         if record.identifiers: # some MODS files don't have identifiers
             meta["identifiers"] = record.identifiers[0].text # MODS allows multiple identifiers, 

--- a/src/aidapta/utils.py
+++ b/src/aidapta/utils.py
@@ -2,8 +2,10 @@ import requests
 import re
 import os
 import pathlib
+import warnings
 from pymods import MODSReader
 from bs4 import BeautifulSoup
+
 
 
 from aidapta.metadata import Person, Faculty, Department
@@ -164,7 +166,12 @@ def extract_mods_metadata(mods_file: str) -> dict:
             languages.append(l)
         meta["language"] = languages
 
-        meta["identifiers"] = record.identifiers[0].text # MODS allows multiple identifiers, 
+        print(record.identifiers)
+        # Identifiers
+        if record.identifiers: # some MODS files don't have identifiers
+            meta["identifiers"] = record.identifiers[0].text # MODS allows multiple identifiers, 
+        else:
+            warnings.warn("No identifiers found in MODS file")
         # only the first one is used. Uuid is used as identifier
         meta["iid"] = record.iid
         meta["internet_media_type"] = record.internet_media_type

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,68 @@
+"""
+Test for metadata pakcage
+"""
+
+import pytest
+import os
+import aidapta.metadata as metadata
+
+
+@pytest.fixture(scope="module")
+def root_path():
+    return './data'
+
+@pytest.fixture(scope="module")
+def file_path():
+    return 'multi-image-caption.pdf'
+
+
+class TestFilePathClass:
+    """ tests for the FilePath class"""
+
+    def test_init(self, root_path, file_path):
+        """
+        test the init method
+        """
+        path = metadata.FilePath(root_path, file_path)
+        assert path.root_path == root_path
+        assert path.file_path == file_path
+
+    def test_post_init(self):
+        """
+        test the post_init method, which check the data types 
+        of root and file pathes
+        """
+        with pytest.raises(TypeError):
+            metadata.FilePath(1000, 'file_path')
+     
+        with pytest.raises(TypeError):
+            metadata.FilePath('root_path', 1000)
+
+    def test_update_root_path(self, root_path, file_path):
+        """
+        test the update_root_path method
+        """
+        _path = metadata.FilePath(root_path, file_path)
+        _path.update_root_path('new_root_path')
+        assert _path.root_path == 'new_root_path'
+
+    def test_full_path(self, root_path, file_path):
+        """
+        test the full_path method
+        """
+        _path = metadata.FilePath(root_path, file_path)
+        assert _path.full_path() == str(os.path.join(root_path, file_path))
+
+
+class TestDocumentClass:
+    """test for the Document class"""
+
+    def test_location_full_path(self, root_path, file_path):
+        """
+        test full path can be generated from the location
+        """
+        _path = metadata.FilePath(root_path, file_path)
+        doc = metadata.Document(_path)
+        assert doc.location.full_path() == str(os.path.join(root_path, file_path))
+   
+


### PR DESCRIPTION
Fix issues found due to inconsistency in metadata and pdf files:

- Ignore the errors when the metadata file has no identifiers
- Ignore unsupported image types by PDFMinderSix
- Enable string paths to documents as root and file paths.
- Delete variables after use to save memory.
- Implement a counter for total visual per entry.